### PR TITLE
Set sanitize dependency to safe version (CVE-2020-4054)

### DIFF
--- a/nono.gemspec
+++ b/nono.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
-  s.add_runtime_dependency "sanitize"
+  s.add_runtime_dependency "sanitize", [">= 5.2.1"]
 end


### PR DESCRIPTION
Hello! A high severity security [vulnerability](https://github.com/advisories/GHSA-p4x4-rw2p-8j8m) was discovered in the `sanitize` gem. 

NoNo doesn't use `sanitize` for rendering concerns so it's not current exposed, strictly speaking. But using the patched version ensures future safety, and will silence various automated dependency checks.